### PR TITLE
firebase id handling

### DIFF
--- a/src/appserver/repository/userRepository.py
+++ b/src/appserver/repository/userRepository.py
@@ -9,15 +9,14 @@ user_collection = app.database.user
 class UserRepository(object):
     @staticmethod
     def insert(user):
-        LOGGER.info('Inserting new vale into user_table')
+        LOGGER.info('Inserting new value into user_table')
         user_id = user_collection.insert_one(user)
         return user_id
 
     @staticmethod
     def update_user_token(facebook_id, token, expires_at):
         LOGGER.info('Updating token to existing user')
-        user_id = user_collection.find_one({'facebookUserId': facebook_id})['_id']
-        user_collection.update_one({'_id': user_id}, {
+        user_collection.update_one({'facebookUserId': facebook_id}, {
             '$set': {
                        'token': token,
                        'expires_at': expires_at
@@ -27,8 +26,7 @@ class UserRepository(object):
     @staticmethod
     def update_firebase_id(facebook_id, firebase_id):
         LOGGER.info('Updating firebase_id to existing user')
-        user_id = user_collection.find_one({'facebookUserId': facebook_id})['_id']
-        user_collection.update_one({'_id': user_id}, {
+        user_collection.update_one({'facebookUserId': facebook_id}, {
             '$set': {
                        'firebase_id': firebase_id
             }

--- a/src/appserver/repository/userRepository.py
+++ b/src/appserver/repository/userRepository.py
@@ -25,6 +25,16 @@ class UserRepository(object):
         }, upsert=False)
 
     @staticmethod
+    def update_firebase_id(facebook_id, firebase_id):
+        LOGGER.info('Updating firebase_id to existing user')
+        user_id = user_collection.find_one({'facebookUserId': facebook_id})['_id']
+        user_collection.update_one({'_id': user_id}, {
+            '$set': {
+                       'firebase_id': firebase_id
+            }
+        }, upsert=False)
+
+    @staticmethod
     def username_exists(facebook_user_id):
         LOGGER.info('Trying to see if ' + facebook_user_id + ' exists in database')
         return user_collection.find_one({'facebookUserId': facebook_user_id}) is not None

--- a/src/appserver/service/UserService.py
+++ b/src/appserver/service/UserService.py
@@ -18,7 +18,7 @@ LOGGER = LoggerFactory().get_logger('UserService')
 class UserService(object):
     @staticmethod
     def register_new_user(request_json):
-        validation_response = JsonValidator.validate_user_authenticate(request_json)
+        validation_response = JsonValidator.validate_user_register(request_json)
         if validation_response.hasErrors:
             return ApplicationResponse.bad_request(message=validation_response.message)
         LOGGER.info("Register user Json is valid")
@@ -48,8 +48,7 @@ class UserService(object):
             LOGGER.error('There was error while getting registering user into shared server. Reason:' + str(e))
             return ApplicationResponse.service_unavailable(message='Could not register user to Shared Server')
 
-        request_json.update({'friendshipList': [request_json['facebookUserId']],
-                             'firebase_id': request_json['firebaseId']})
+        request_json.update({'friendshipList': [request_json['facebookUserId']]})
         UserRepository.insert(request_json)
 
         return ApplicationResponse.created(message='Created user successfully')
@@ -84,6 +83,8 @@ class UserService(object):
         token = data["token"]
         expires_at = data["expires_at"]
         UserRepository.update_user_token(facebook_id, token, expires_at)
+        firebase_id = request_json['firebaseId']
+        UserRepository.update_firebase_id(facebook_id, firebase_id)
         response = {'message': 'Logged in successfully.', 'token': token}
         return ApplicationResponse.success(data=response)
 

--- a/src/appserver/service/UserService.py
+++ b/src/appserver/service/UserService.py
@@ -120,7 +120,10 @@ class UserService(object):
         title = requester_name + ' quiere ser tu amigo'
         body = {'mMessage': requester_message}
 
-        FirebaseCloudMessaging.send_notification(title=title, body=body, list_of_firebase_ids=target['firebase_id'])
+        try:
+            FirebaseCloudMessaging.send_notification(title=title, body=body, list_of_firebase_ids=target['firebase_id'])
+        except:
+            LOGGER.warn('No firebase Id found for user, not sending push notification')
 
     @staticmethod
     def get_friendship_requests(request_header):
@@ -158,7 +161,10 @@ class UserService(object):
         title = acceptor_name + ' ha aceptado tu solicitud de amistad'
         body = {'mMessage': 'Tú y ' + acceptor_name + ' ahora son amigos'}
 
-        FirebaseCloudMessaging.send_notification(title=title, body=body, list_of_firebase_ids=target['firebase_id'])
+        try:
+            FirebaseCloudMessaging.send_notification(title=title, body=body, list_of_firebase_ids=target['firebase_id'])
+        except:
+            LOGGER.warn('No firebase Id found for user, not sending push notification')
 
     @staticmethod
     def modify_user_profile(request_json, request_header):

--- a/src/appserver/validator/authValidator.py
+++ b/src/appserver/validator/authValidator.py
@@ -3,6 +3,7 @@ from flask import request
 from appserver.logger import LoggerFactory
 from appserver import app
 from appserver.datastructure.ApplicationResponse import ApplicationResponse
+from appserver.repository.userRepository import UserRepository
 import time
 
 LOGGER = LoggerFactory.get_logger(__name__)
@@ -31,6 +32,10 @@ def secure(method):
         timestamp_now = int(time.time())
         if (timestamp_now > int(user['expires_at'])) and (app.skip_auth is False):
             return ApplicationResponse.unauthorized('Provided token expired')
+
+        firebase_id = request.headers.get('firebaseId')
+        if firebase_id is not None:
+            UserRepository.update_firebase_id(facebook_id, firebase_id)
 
         return method(*args, **kwargs)
 

--- a/src/appserver/validator/jsonValidator.py
+++ b/src/appserver/validator/jsonValidator.py
@@ -26,7 +26,6 @@ class JsonValidator(object):
         validation_response = JsonValidator.__check_validity_json(json, 'facebookUserId', validation_response)
         validation_response = JsonValidator.__check_validity_json(json, 'facebookAuthToken', validation_response)
         validation_response = JsonValidator.__check_validity_json(json, 'firebaseId', validation_response)
-
         return validation_response
 
     @staticmethod

--- a/src/tests/app/allTestsAreHereForNow.py
+++ b/src/tests/app/allTestsAreHereForNow.py
@@ -63,14 +63,12 @@ class Tests(BaseTestCase):
         self.assertEqual(inserted_user['facebookAuthToken'], 'facebookAuthToken')
         self.assertEqual(inserted_user['last_name'], 'last_name')
         self.assertEqual(inserted_user['first_name'], 'first_name')
-        self.assertEqual(inserted_user['firebase_id'], 'firebaseId')
 
     def test_register_existing_user_doesnt_add_it_again(self):
         Tests.__create_default_user()
         response_register_user = UserService.register_new_user(
             {'facebookUserId': 'facebookUserId',
-             'facebookAuthToken': 'facebookAuthToken',
-             'firebaseId': 'firebaseId'})
+             'facebookAuthToken': 'facebookAuthToken'})
 
         self.assertEqual(response_register_user.status_code, 400)
         self.assertEqual(response_register_user.get_json()['message'], 'User already registered.')
@@ -112,8 +110,7 @@ class Tests(BaseTestCase):
 
     def test_send_friendship_request(self):
         Tests.__create_default_user()
-        UserService.register_new_user({'facebookUserId': 'target', 'facebookAuthToken': 'facebookAuthToken',
-                                       'firebaseId': 'firebaseId'})
+        UserService.register_new_user({'facebookUserId': 'target', 'facebookAuthToken': 'facebookAuthToken'})
         response_send_friendship_request = UserService.send_user_friendship_request(
             {'mTargetUsername': 'target', 'mDescription': 'Add me to your friend list'},
             {'facebookUserId': 'facebookUserId'})
@@ -128,8 +125,7 @@ class Tests(BaseTestCase):
 
     def test_get_friendship_requests(self):
         Tests.__create_default_user()
-        UserService.register_new_user({'facebookUserId': 'target', 'facebookAuthToken': 'facebookAuthToken',
-                                       'firebaseId': 'firebaseIdTarget'})
+        UserService.register_new_user({'facebookUserId': 'target', 'facebookAuthToken': 'facebookAuthToken'})
         UserService.send_user_friendship_request(
             {'mTargetUsername': 'target', 'mDescription': 'Add me to your friend list'},
             {'facebookUserId': 'facebookUserId'})
@@ -146,10 +142,8 @@ class Tests(BaseTestCase):
         self.assertEqual(friendship_list[0]['message'], 'Add me to your friend list')
 
     def test_accept_friendship_request(self):
-        UserService.register_new_user({'facebookUserId': 'target', 'facebookAuthToken': 'facebookAuthToken',
-                                       'firebaseId': 'firebaseIdTarget'})
-        UserService.register_new_user({'facebookUserId': 'requester', 'facebookAuthToken': 'facebookAuthToken',
-                                       'firebaseId': 'firebaseIdRequester'})
+        UserService.register_new_user({'facebookUserId': 'target', 'facebookAuthToken': 'facebookAuthToken'})
+        UserService.register_new_user({'facebookUserId': 'requester', 'facebookAuthToken': 'facebookAuthToken'})
         UserService.send_user_friendship_request(
             {'mTargetUsername': 'target', 'mDescription': 'Add me to your friend list'},
             {'facebookUserId': 'requester'})
@@ -371,8 +365,7 @@ class Tests(BaseTestCase):
     @staticmethod
     def __create_default_user():
         return UserService.register_new_user({'facebookUserId': 'facebookUserId',
-                                              'facebookAuthToken': 'facebookAuthToken',
-                                              'firebaseId': 'firebaseId'})
+                                              'facebookAuthToken': 'facebookAuthToken'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
required firebase id on login
removed firebase id from registration
optionally it can be sent on request headers in case of refresh